### PR TITLE
Move preview panel's error message to the bottom and add diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "Programming Languages"
     ],
     "activationEvents": [
+        "onLanguage:prql",
         "onCommand:prqlSqlOutputPanel.open"
     ],
     "source": "src/extension.ts",

--- a/resources/sql_output.css
+++ b/resources/sql_output.css
@@ -32,21 +32,30 @@ code {
   font-weight: var(--vscode-editor-font-weight) !important;
 }
 
-hr {
-  border-width: 1px;
-  border-style: solid;
-  border-color: var(--vscode-editorError-foreground);
-  display: none;
-}
-
 h3 {
+  margin: 10px 0 0 10px;
   color: var(--vscode-editorError-foreground);
-  margin-bottom: 0;
 }
 
-#error_message {
-  display: none;
-  margin-top: 10px;
-  color: var(--vscode-editorError-foreground);
+#last-html {
   overflow-y: scroll;
+  max-height: 80vh;
+  margin-top: 0px;
+}
+
+#error-container {
+  overflow-x: scroll;
+  color: var(--vscode-editorError-foreground);
+}
+
+.error-container-fixed {
+  left: 20px;
+  right: 20px;
+  bottom: 0;
+  position: fixed;
+  border-top: 2px solid var(--vscode-editorError-foreground);
+}
+
+#error-message {
+  padding-left: 10px;
 }

--- a/resources/sql_output.css
+++ b/resources/sql_output.css
@@ -46,6 +46,7 @@ h3 {
 #error-container {
   overflow-x: scroll;
   color: var(--vscode-editorError-foreground);
+  background-color: var(--vscode-editor-background);
 }
 
 .error-container-fixed {

--- a/resources/sql_output.html
+++ b/resources/sql_output.html
@@ -16,10 +16,13 @@
 </template>
 
 <template id="status-error">
-  <h3>Syntax error!</h3>
-  <pre id="error_message"></pre>
-  <hr id="separator">
-  <pre id="last_html"></pre>
+  <div class="error-inner">
+    <pre id="last-html"></pre>
+    <div id="error-container">
+      <h3>Syntax error!</h3>
+      <pre id="error-message"></pre>
+    </div>
+  </div>
 </template>
 
 <template id="status-theme-changed">

--- a/resources/sql_output.js
+++ b/resources/sql_output.js
@@ -2,19 +2,21 @@ window.addEventListener("message", event => {
   const { status, content, last_html } = event.data;
   const template = document.getElementById(`status-${status}`).content.cloneNode(true);
 
+  const el = name => template.getElementById(name);
+
   switch (status) {
     case "ok":
       template.lastElementChild.innerHTML = content;
       break;
     case "error":
       if (last_html) {
-        template.getElementById("last_html").innerHTML = last_html;
-        template.getElementById("separator").style.display = "block";
+        el("last-html").innerHTML = last_html;
+        el("error-container").classList.add("error-container-fixed");
       }
-      const el = template.getElementById("error_message");
+
       if (content.length > 0) {
-        el.innerHTML = content;
-        el.style.display = "block";
+        el("error-message").innerHTML = content;
+        el("error-container").style.display = "block";
       }
       break;
     case "theme-changed":

--- a/resources/sql_output.js
+++ b/resources/sql_output.js
@@ -1,21 +1,23 @@
 window.addEventListener("message", event => {
-  const { status, content, last_html } = event.data;
+  const { status } = event.data;
   const template = document.getElementById(`status-${status}`).content.cloneNode(true);
 
   const el = name => template.getElementById(name);
 
   switch (status) {
     case "ok":
-      template.lastElementChild.innerHTML = content;
+      template.lastElementChild.innerHTML = event.data.html;
       break;
     case "error":
-      if (last_html) {
-        el("last-html").innerHTML = last_html;
+      const { error: { message }, last_html: lastHtml } = event.data;
+
+      if (lastHtml) {
+        el("last-html").innerHTML = lastHtml;
         el("error-container").classList.add("error-container-fixed");
       }
 
-      if (content.length > 0) {
-        el("error-message").innerHTML = content;
+      if (message.length > 0) {
+        el("error-message").innerHTML = message;
         el("error-container").style.display = "block";
       }
       break;

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,0 +1,44 @@
+import * as vscode from "vscode";
+import { compile, SourceLocation } from "prql-js";
+import { isPrqlDocument } from "./utils";
+
+function getRange(location: SourceLocation | undefined): vscode.Range {
+  if (location) {
+    return new vscode.Range(location.start_line, location.start_column, location.end_line,
+      location.end_column);
+  }
+
+  return new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0));
+}
+
+function updateLineDiagnostics(diagnosticCollection: vscode.DiagnosticCollection) {
+  const editor = vscode.window.activeTextEditor;
+
+  if (editor && isPrqlDocument(editor)) {
+    const text = editor.document.getText();
+    const result = compile(text);
+
+    if (result.sql) {
+      diagnosticCollection.set(editor.document.uri, []);
+    } else {
+      const range = getRange(result.error?.location);
+      const diagnostic = new vscode.Diagnostic(range, result.error?.message ?? "Syntax Error",
+        vscode.DiagnosticSeverity.Error);
+      diagnosticCollection.set(editor.document.uri, [diagnostic]);
+    }
+  }
+}
+
+export function activateDiagnostics(context: vscode.ExtensionContext) {
+  const diagnosticCollection = vscode.languages.createDiagnosticCollection("prql");
+  context.subscriptions.push(diagnosticCollection);
+
+  [
+    vscode.workspace.onDidChangeTextDocument,
+    vscode.window.onDidChangeActiveTextEditor
+  ].forEach(event => {
+    context.subscriptions.push(event(() => updateLineDiagnostics(diagnosticCollection)));
+  });
+
+  updateLineDiagnostics(diagnosticCollection);
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,8 @@
 import * as vscode from "vscode";
 import { activateSqlOutputPanel } from "./sql_output";
+import { activateDiagnostics } from "./diagnostics";
 
 export function activate(context: vscode.ExtensionContext) {
+  activateDiagnostics(context);
   activateSqlOutputPanel(context);
 }

--- a/src/sql_output/utils.ts
+++ b/src/sql_output/utils.ts
@@ -1,17 +1,17 @@
 import * as vscode from "vscode";
+import { SourceLocation } from "prql-js";
 
 export interface CompilationResult {
   status: "ok" | "error";
-  content: string;
+  html?: string;
+  error?: {
+    message: string;
+  }
   last_html?: string | undefined;
 }
 
 export function getResourceUri(context: vscode.ExtensionContext, filename: string) {
   return vscode.Uri.joinPath(context.extensionUri, "resources", filename);
-}
-
-export function isPrqlDocument(editor: vscode.TextEditor): boolean {
-  return editor.document.fileName.endsWith(".prql");
 }
 
 export function normalizeThemeName(currentTheme: string): string {

--- a/src/sql_output/utils.ts
+++ b/src/sql_output/utils.ts
@@ -1,5 +1,4 @@
 import * as vscode from "vscode";
-import { SourceLocation } from "prql-js";
 
 export interface CompilationResult {
   status: "ok" | "error";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,5 @@
+import * as vscode from "vscode";
+
+export function isPrqlDocument(editor: vscode.TextEditor): boolean {
+  return editor.document.fileName.endsWith(".prql");
+}


### PR DESCRIPTION
Hello!

- Moves the preview panel's error message to the bottom if there's any previously rendered HTML. The error message should be visible even if the HTML output is long since it's fixed to the bottom of the window.
  <img width="563" alt="image" src="https://user-images.githubusercontent.com/20820/191851467-bf8cfa65-1b60-481d-a85c-547ee1ae4b88.png">

- Add diagnostics. Clicking on the error will take users to the line with the error. Hovering will display the error.
  
  <img width="393" alt="image" src="https://user-images.githubusercontent.com/20820/191851841-c4d49441-6b4b-443c-b74f-6cb14ea96dff.png">

As you can see in the diagnostic message, it uses the formatted message from the error. Unfortunately, the formatting is kind of messed up and actually the code snippet feels redundant. It would be nice if the `prql-js` library had a "plain" message that I could use instead. Since the library doesn't have a stable version yet, I would go as far as to rename the current `message` to `formatted_message` and expose the "plain" message as `message` instead.

While testing, I noticed some errors do not come with location information (e.g. `from foo | select 2bar` -> "bad select definition"). In this case, I use 0,0 as the source of the error but obviously that highlights the wrong thing. I guess the parser needs some more love.


